### PR TITLE
simple fix to change log_notice to log_info.  As per changes in Kodi.

### DIFF
--- a/script.service.next-episode/service.py
+++ b/script.service.next-episode/service.py
@@ -4,11 +4,11 @@
 # License: GPL v. 3 <http://www.gnu.org/licenses/gpl-3.0.en.html>
 
 from __future__ import unicode_literals
-from libs.logger import log_notice
+from libs.logger import log_info
 from libs.monitoring import UpdateMonitor, initial_prompt
 
 initial_prompt()
 update_monitor = UpdateMonitor()
-log_notice('Service started')
+log_info('Service started')
 update_monitor.waitForAbort()
-log_notice('Service stopped')
+log_info('Service stopped')


### PR DESCRIPTION
Hello.  Long time user of next-episode.net.  New to github/PRs, etc.

Please accept this PR.  It is a simple change as per issue https://github.com/santah/next-episode-kodi/issues/3

I tested this on OSMC with Kodi 18.7.

2020-09-19 08:33:15.813 T:1915270704  NOTICE: Starting Kodi (18.7). Platform: Linux ARM (Thumb) 32-bit
2020-09-19 08:33:15.813 T:1915270704  NOTICE: Using Release Kodi x32 build (version for Raspberry Pi)
2020-09-19 08:33:15.814 T:1915270704  NOTICE: Kodi compiled 2020-06-03 by GCC 6.3.0 for Linux ARM (Thumb) 32-bit version 4.9.110 (264558)
2020-09-19 08:33:15.814 T:1915270704  NOTICE: Running on Open Source Media Center 2020.06-1, kernel: Linux ARM 32-bit version 4.19.122-1-osmc
